### PR TITLE
refactor: export API utilities and add validation

### DIFF
--- a/getRealtimePrice.js
+++ b/getRealtimePrice.js
@@ -1,22 +1,27 @@
 
-async function getRealtimePrice(code, apiToken = "demo") {
-  const url = `https://eodhd.com/api/real-time/${encodeURIComponent(code)}?api_token=${encodeURIComponent(apiToken)}&fmt=json`;
-
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-
-    return {
-      ticker: code,
-      price: data.close,
-      timestamp: data.timestamp,
-      change: data.change,
-      change_percent: data.change_p,
-    };
-  } catch (error) {
-    return { error: error.message };
+export async function getRealtimePrice(code, apiToken = "demo") {
+  if (typeof code !== "string" || !code.trim()) {
+    throw new Error("code must be a non-empty string");
   }
-}
+  if (typeof apiToken !== "string" || !apiToken.trim()) {
+    throw new Error("apiToken must be a non-empty string");
+  }
 
-// Example:
-getRealtimePrice("AAPL.US").then(console.log);
+  const url = `https://eodhd.com/api/real-time/${encodeURIComponent(
+    code
+  )}?api_token=${encodeURIComponent(apiToken)}&fmt=json`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  const data = await response.json();
+
+  return {
+    ticker: code,
+    price: data.close,
+    timestamp: data.timestamp,
+    change: data.change,
+    change_percent: data.change_p,
+  };
+}

--- a/getTechnicalIndicator.js
+++ b/getTechnicalIndicator.js
@@ -1,30 +1,47 @@
 
-async function getTechnicalIndicator(code, func = "rsi", period = 14, apiToken = "demo") {
+export async function getTechnicalIndicator(
+  code,
+  func = "rsi",
+  period = 14,
+  apiToken = "demo"
+) {
+  if (typeof code !== "string" || !code.trim()) {
+    throw new Error("code must be a non-empty string");
+  }
+  if (typeof func !== "string" || !func.trim()) {
+    throw new Error("func must be a non-empty string");
+  }
+  if (!Number.isInteger(period) || period <= 0) {
+    throw new Error("period must be a positive integer");
+  }
+  if (typeof apiToken !== "string" || !apiToken.trim()) {
+    throw new Error("apiToken must be a non-empty string");
+  }
+
   const now = new Date();
   const to = now.toISOString().slice(0, 10); // YYYY-MM-DD
-  const fromDate = new Date(now.getTime() - (period * 5 * 24 * 60 * 60 * 1000)); // Buffer for enough data
+  const fromDate = new Date(now.getTime() - period * 5 * 24 * 60 * 60 * 1000); // Buffer for enough data
   const from = fromDate.toISOString().slice(0, 10);
 
-  const url = `https://eodhd.com/api/technical-indicators/${encodeURIComponent(code)}?function=${encodeURIComponent(func)}&period=${period}&from=${from}&to=${to}&api_token=${encodeURIComponent(apiToken)}&fmt=json`;
+  const url = `https://eodhd.com/api/technical-indicators/${encodeURIComponent(
+    code
+  )}?function=${encodeURIComponent(func)}&period=${period}&from=${from}&to=${to}&api_token=${encodeURIComponent(
+    apiToken
+  )}&fmt=json`;
 
-  try {
-    const response = await fetch(url);
-    const data = await response.json();
-
-    if (Array.isArray(data) && data.length > 0) {
-      const latest = data[data.length - 1];
-      return {
-        ticker: code,
-        date: latest.date,
-        value: latest[func],
-      };
-    } else {
-      return { error: "No data received", raw: data };
-    }
-  } catch (error) {
-    return { error: error.message };
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
   }
-}
+  const data = await response.json();
 
-// Example:
-getTechnicalIndicator("AAPL.US", "rsi", 14).then(console.log);
+  if (Array.isArray(data) && data.length > 0) {
+    const latest = data[data.length - 1];
+    return {
+      ticker: code,
+      date: latest.date,
+      value: latest[func],
+    };
+  }
+  throw new Error("No data received");
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bubblechart",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/test.js"
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,49 @@
+import assert from 'node:assert';
+import { getRealtimePrice } from '../getRealtimePrice.js';
+import { getTechnicalIndicator } from '../getTechnicalIndicator.js';
+
+async function runTests() {
+  // getRealtimePrice parameter validation
+  await assert.rejects(() => getRealtimePrice(''), /code must be a non-empty string/);
+
+  // getRealtimePrice success
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ close: 100, timestamp: 123, change: 1, change_p: 2 })
+  });
+  const price = await getRealtimePrice('AAPL.US');
+  assert.deepStrictEqual(price, {
+    ticker: 'AAPL.US',
+    price: 100,
+    timestamp: 123,
+    change: 1,
+    change_percent: 2
+  });
+
+  // getRealtimePrice fetch error
+  global.fetch = async () => { throw new Error('network'); };
+  await assert.rejects(() => getRealtimePrice('AAPL.US'), /network/);
+
+  // getTechnicalIndicator parameter validation
+  await assert.rejects(() => getTechnicalIndicator('AAPL.US', 'rsi', 0), /period must be a positive integer/);
+
+  // getTechnicalIndicator success
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ([{ date: '2024-01-01', rsi: 55 }])
+  });
+  const ind = await getTechnicalIndicator('AAPL.US', 'rsi', 14);
+  assert.deepStrictEqual(ind, {
+    ticker: 'AAPL.US',
+    date: '2024-01-01',
+    value: 55
+  });
+
+  // getTechnicalIndicator fetch error
+  global.fetch = async () => { throw new Error('network'); };
+  await assert.rejects(() => getTechnicalIndicator('AAPL.US', 'rsi', 14), /network/);
+
+  console.log('All tests passed');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- export API helpers and remove example calls
- validate input parameters and propagate fetch errors
- add node-based tests and module config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0841fd8b8832eb3b15b889aed32b3