### PR TITLE
feat: client overlays for chat-driven chart

### DIFF
--- a/ChartContext.js
+++ b/ChartContext.js
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useState } from "react";
+import { mergeActions } from "./chartUtils";
+
+export const ChartContext = createContext({ actions: [], setActions: () => {} });
+
+export function ChartProvider({ children }) {
+  const [actions, setActions] = useState([]);
+  return (
+    <ChartContext.Provider value={{ actions, setActions }}>
+      {children}
+    </ChartContext.Provider>
+  );
+}
+
+export function useChart() {
+  return useContext(ChartContext);
+}
+
+export { mergeActions };

--- a/chartUtils.js
+++ b/chartUtils.js
@@ -1,0 +1,12 @@
+export function mergeActions(existing = [], incoming = []) {
+  const out = [...existing];
+  for (const a of incoming) {
+    const idx = out.findIndex((b) => b.label === a.label);
+    if (idx >= 0) {
+      out[idx] = { ...out[idx], ...a };
+    } else {
+      out.push(a);
+    }
+  }
+  return out;
+}

--- a/chartUtils.test.js
+++ b/chartUtils.test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import { mergeActions } from './chartUtils.js';
+
+const initial = [{ type: 'hline', label: 'ENTRY', price: 100 }];
+const added = mergeActions(initial, [{ type: 'hline', label: 'SL', price: 90 }]);
+assert.strictEqual(added.length, 2);
+assert.strictEqual(added.find(a => a.label === 'SL').price, 90);
+
+const modified = mergeActions(added, [{ type: 'hline', label: 'ENTRY', price: 110 }]);
+assert.strictEqual(modified.length, 2);
+assert.strictEqual(modified.find(a => a.label === 'ENTRY').price, 110);
+
+console.log('chartUtils tests passed');


### PR DESCRIPTION
## Summary
- replace TradingView chart with client-only LightweightPriceChart
- share chart actions via context so chat messages can draw entry/SL/TP
- merge agent-streamed annotations into chart overlays

## Testing
- `node chartUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c08420ec78832e95089837f14a7b7e