### PR TITLE
feat: centralize market state with context provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/LightweightPriceChart.jsx
+++ b/LightweightPriceChart.jsx
@@ -8,6 +8,7 @@
 
 "use client";
 import React, { useEffect, useMemo, useRef } from "react";
+import { useMarket } from './MarketContext';
 
 /* ---------- Browser-safe history fetch ---------- */
 async function getBarsClient({ symbol, timeframe, debug }) {
@@ -160,8 +161,6 @@ function tfToSec(tf) {
 }
 
 export default function LightweightPriceChart({
-  symbol = "BTCUSD",
-  timeframe = "1h", // "1m" | "5m" | "15m" | "1h" | "4h" | "1d"
   actions = [], // [{type:'hline', price, label}]
   onPriceUpdate,
   watermarkSrc = DEFAULT_WATERMARK,
@@ -169,6 +168,7 @@ export default function LightweightPriceChart({
   showResetViewButton = true,
   decimals = 2,           // <<--- NEW
 }) {
+  const { symbol, timeframe } = useMarket();
 
   const containerRef = useRef(null);
   const chartRef = useRef(null);

--- a/MarketContext.js
+++ b/MarketContext.js
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const MarketContext = createContext(null);
+
+export function MarketProvider({
+  children,
+  initialSymbol = 'XAUUSD',
+  initialTimeframe = '15m'
+}) {
+  const [symbol, setSymbolState] = useState(initialSymbol);
+  const [timeframe, setTimeframeState] = useState(initialTimeframe);
+
+  const setSymbol = useCallback((s) => setSymbolState(s), []);
+  const setTimeframe = useCallback((t) => setTimeframeState(t), []);
+
+  const value = { symbol, timeframe, setSymbol, setTimeframe };
+  return React.createElement(MarketContext.Provider, { value }, children);
+}
+
+export function useMarket() {
+  const ctx = useContext(MarketContext);
+  if (!ctx) throw new Error('useMarket must be used within MarketProvider');
+  return ctx;
+}
+
+export default MarketContext;

--- a/MarketContext.test.js
+++ b/MarketContext.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+import { MarketProvider, useMarket } from './MarketContext.js';
+
+test('MarketProvider shares symbol and timeframe with setters', () => {
+  let ctx;
+  function Consumer() {
+    ctx = useMarket();
+    return null;
+  }
+  create(
+    React.createElement(
+      MarketProvider,
+      { initialSymbol: 'EURUSD', initialTimeframe: '1h' },
+      React.createElement(Consumer)
+    )
+  );
+  assert.equal(ctx.symbol, 'EURUSD');
+  assert.equal(ctx.timeframe, '1h');
+  act(() => ctx.setSymbol('BTCUSD'));
+  assert.equal(ctx.symbol, 'BTCUSD');
+  act(() => ctx.setTimeframe('15m'));
+  assert.equal(ctx.timeframe, '15m');
+});

--- a/conversationMetadata.js
+++ b/conversationMetadata.js
@@ -1,0 +1,15 @@
+export async function updateConversationMetadata({ conversationId, symbol, timeframe }) {
+  if (!conversationId) return;
+  try {
+    await fetch('/functions/publicAgentConversations', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversation_id: conversationId,
+        metadata: { symbol, timeframe }
+      })
+    });
+  } catch (err) {
+    console.error('Failed to update conversation metadata', err);
+  }
+}

--- a/conversationMetadata.test.js
+++ b/conversationMetadata.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { updateConversationMetadata } from './conversationMetadata.js';
+
+test('updateConversationMetadata posts correct payload', async () => {
+  const calls = [];
+  global.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return { ok: true };
+  };
+  await updateConversationMetadata({ conversationId: '123', symbol: 'BTCUSD', timeframe: '1h' });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, '/functions/publicAgentConversations');
+  const body = JSON.parse(calls[0].options.body);
+  assert.deepEqual(body, {
+    conversation_id: '123',
+    metadata: { symbol: 'BTCUSD', timeframe: '1h' }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,117 @@
+{
+  "name": "bubblechart",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bubblechart",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
+      "devDependencies": {
+        "react-test-renderer": "^18.2.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bubblechart",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "react-test-renderer": "^18.2.0"
+  }
+}

--- a/publicchatBubble.js
+++ b/publicchatBubble.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTheme } from './ui/Theme';
 import { Send, Bot, User, AlertCircle, RefreshCw } from 'lucide-react';
+import { useMarket } from './MarketContext';
+import { updateConversationMetadata } from './conversationMetadata';
 
 // Generate and persist guest ID
 function getGuestId() {
@@ -72,8 +74,7 @@ export default function PublicAgentBubble() {
   const [conversationId, setConversationId] = useState(null);
   const [error, setError] = useState(null);
   const [isInitializing, setIsInitializing] = useState(true);
-  const [symbol, setSymbol] = useState("XAUUSD");
-  const [timeframe, setTimeframe] = useState("15m");
+  const { symbol, timeframe, setSymbol, setTimeframe } = useMarket();
   
   const endRef = useRef(null);
   const eventSourceRef = useRef(null);
@@ -223,7 +224,17 @@ export default function PublicAgentBubble() {
         eventSourceRef.current.close();
       }
     };
-  }, [language, symbol, timeframe]);
+  }, [language]);
+
+  const prevConversationId = useRef(null);
+  useEffect(() => {
+    if (!conversationId) return;
+    if (prevConversationId.current !== conversationId) {
+      prevConversationId.current = conversationId;
+      return; // Skip initial update after creation
+    }
+    updateConversationMetadata({ conversationId, symbol, timeframe });
+  }, [conversationId, symbol, timeframe]);
 
   // Auto-scroll to bottom
   useEffect(() => {


### PR DESCRIPTION
## Summary
- create `MarketProvider` to share symbol/timeframe and setters across components
- wire chart and public chat bubble to context and propagate metadata updates
- add unit tests for context and conversation metadata utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08422bba0832eb97e2a52d01f105e